### PR TITLE
marsRover13-1 Adds apod endpoint for retrieval of image and explanation

### DIFF
--- a/server/middleware/getApod.js
+++ b/server/middleware/getApod.js
@@ -1,0 +1,34 @@
+const axios = require('axios');
+const { NASA_API_KEY } = require('../../config/apiCredentials');
+
+const queryParameters = {
+	params: {
+		api_key: NASA_API_KEY,
+	},
+};
+
+const getApod = async () => {
+	try {
+		const apodData = await axios.get(
+			'https://api.nasa.gov/planetary/apod',
+			queryParameters
+		);
+		return apodData;
+	} catch (error) {
+		console.error('Error', error);
+	}
+};
+
+const getApodImageAndExplanation = async (request, response) => {
+	try {
+		const body = await getApod();
+		const { url, explanation } = body.data;
+		response.send({ url, explanation });
+	} catch (error) {
+		console.error('Error', error);
+	}
+};
+
+module.exports = {
+	getApodImageAndExplanation,
+};

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -1,13 +1,15 @@
 const express = require('express');
 const { checkForUser } = require('../middleware/checkForUser');
 const { setJwtOnAccessToken } = require('../middleware/setJwt');
+const { getApodImageAndExplanation } = require('../middleware/getApod');
 
 const router = express.Router();
 
 router.use('/login', express.static('app/login'));
+router.use('/rover', express.static('app/marsRoverPath'));
+
+router.get('/apod', getApodImageAndExplanation);
 
 router.post('/authenticate', checkForUser, setJwtOnAccessToken);
-
-router.use('/rover', express.static('app/marsRoverPath'));
 
 module.exports = router;


### PR DESCRIPTION
**Due to an error in pushing to branches, this branch is now redundant**
See #26 for replacement branch

**Description**
On the home page, instead of a static picture, display NASA's astronomy picture of the day, and instead of a static welcome message, display the explanation that comes with the picture. 
This ticket is for the first part of that ticket and creates the endpoint which serves the image url and explanation.

**Changes**
* Adds route on `/apod`
* Adds middleware to retrieve the image url and the explanation from the NASA APOD API