### PR TITLE
marsRover13-2: Renders the APOD image and text on the homepage

### DIFF
--- a/app/homepage/index.html
+++ b/app/homepage/index.html
@@ -14,8 +14,8 @@
             <h4 id="kennedyTimeNow">The current time at Kennedy Space Centre: </h4>
         </div>
         <img id="apod"src="https://images-assets.nasa.gov/image/PIA22110/PIA22110~orig.jpg" alt="A photo of the Mars Rover">
+        <h3 id="image-caption">The Mars Rover</h3>
         <p id="apod-explanation"></p>
-        <h3>The latest views from the Mars Rover!</h3>
         <a href="/login">Login to your NASA account.</a>
         <h2 id="sol-number">The Curiosity Rover has been on Mars for: </h2>
         <h2 id="earth-number">The Curiosity Rover has been on Mars for: </h2>

--- a/app/homepage/index.html
+++ b/app/homepage/index.html
@@ -13,7 +13,8 @@
             <h4 id="kennedyTime">You are: </h4>
             <h4 id="kennedyTimeNow">The current time at Kennedy Space Centre: </h4>
         </div>
-        <img src="https://images-assets.nasa.gov/image/PIA22110/PIA22110~orig.jpg" alt="A photo of the Mars Rover">
+        <img id="apod"src="https://images-assets.nasa.gov/image/PIA22110/PIA22110~orig.jpg" alt="A photo of the Mars Rover">
+        <p id="apod-explanation"></p>
         <h3>The latest views from the Mars Rover!</h3>
         <a href="/login">Login to your NASA account.</a>
         <h2 id="sol-number">The Curiosity Rover has been on Mars for: </h2>

--- a/app/homepage/index.js
+++ b/app/homepage/index.js
@@ -57,6 +57,8 @@ const getPhotoOfTheDay = () => {
 			document.getElementById(
 				'apod-explanation'
 			).innerText = `${data.explanation}`;
+			document.getElementById('image-caption').innerText =
+        'The Astronomy Photo Of The Day';
 		});
 };
 

--- a/app/homepage/index.js
+++ b/app/homepage/index.js
@@ -48,7 +48,7 @@ const addNumberOfEarthDays = () => {
 };
 
 const getPhotoOfTheDay = () => {
-	fetch('http://localhost:3000/apod')
+	fetch('/apod')
 		.then((response) => {
 			return response.json();
 		})
@@ -59,6 +59,9 @@ const getPhotoOfTheDay = () => {
 			).innerText = `${data.explanation}`;
 			document.getElementById('image-caption').innerText =
         'The Astronomy Photo Of The Day';
+		})
+		.catch((error) => {
+			console.log(`Unable to retieve photo: ${error.message}`);
 		});
 };
 

--- a/app/homepage/index.js
+++ b/app/homepage/index.js
@@ -47,6 +47,20 @@ const addNumberOfEarthDays = () => {
 		.append(`${Math.round(earthDaysSinceLanding)} Earth days`);
 };
 
+const getPhotoOfTheDay = () => {
+	fetch('http://localhost:3000/apod')
+		.then((response) => {
+			return response.json();
+		})
+		.then((data) => {
+			document.getElementById('apod').setAttribute('src', `${data.url}`);
+			document.getElementById(
+				'apod-explanation'
+			).innerText = `${data.explanation}`;
+		});
+};
+
+getPhotoOfTheDay();
 addNumberOfSols();
 addNumberOfEarthDays();
 addTodaysDate();

--- a/server/services/getApodPhotoOfTheDay.js
+++ b/server/services/getApodPhotoOfTheDay.js
@@ -10,7 +10,7 @@ const queryParameters = {
 const getApodImageAndExplanation = async () => {
 	try {
 		const apodData = await axios.get(
-			'https://api.nasa.gov/planetary/apo',
+			'https://api.nasa.gov/planetary/apod',
 			queryParameters
 		);
 		return apodData;

--- a/server/services/getApodPhotoOfTheDay.js
+++ b/server/services/getApodPhotoOfTheDay.js
@@ -10,7 +10,7 @@ const queryParameters = {
 const getApodImageAndExplanation = async () => {
 	try {
 		const apodData = await axios.get(
-			'https://api.nasa.gov/planetary/apod',
+			'https://api.nasa.gov/planetary/apo',
 			queryParameters
 		);
 		return apodData;


### PR DESCRIPTION
**Description**
On the home page, instead of a static picture, display NASA's astronomy picture of the day, and instead of a static welcome message, display the explanation that comes with the picture.

This PR completes the ticket with the rendering of the APOD image and url on the homepage.

**Changes**
* Adds a fetch request to the `/apod` endpoint
* Renders the apod image when it is available
* Renders the rover image when the apod API is not available
