### PR TITLE
marsRover56: sprite snaps to specific points on the rover path

### DIFF
--- a/app/marsRoverPath/index.js
+++ b/app/marsRoverPath/index.js
@@ -13,7 +13,7 @@ const positionRoverAtStartOfPath = () => {
 		roverMap.offsetHeight * scalingFactorFromTop +
     roverMap.getBoundingClientRect().top
 	}px`;
-
+	console.log('x', spriteImage.style.left, 'y', spriteImage.style.top);
 	window.addEventListener('resize', () => {
 		spriteImage.style.left = `${
 			roverMap.offsetWidth * scalingFactorFromLeft +
@@ -44,7 +44,7 @@ const dragAndDropRover = () => {
 
 	let active = false;
 
-	const roverSprite = document.getElementById('#rover-sprite');
+	const roverSprite = document.getElementById('rover-sprite');
 
 	const dragStart = (event) => {
 		initialMousePosition.x = event.clientX - offset.x;
@@ -58,6 +58,13 @@ const dragAndDropRover = () => {
 		initialMousePosition.x = currentMousePosition.x;
 		initialMousePosition.y = currentMousePosition.y;
 
+		console.log(
+			'DRAG END',
+			'x',
+			initialMousePosition.x,
+			'y',
+			initialMousePosition.y
+		);
 		active = false;
 	};
 
@@ -65,11 +72,39 @@ const dragAndDropRover = () => {
 		element.style.transform = 'translate(' + xPos + 'px, ' + yPos + 'px)';
 	};
 
+	const calculateXcoordinateUpper = (yCoordinate) => {
+		const gradient = -545 / 500;
+		const constant = 700 - 600 * gradient;
+		return (yCoordinate - constant) / gradient;
+	};
+
+	const calculateXcoordinateMiddle = (yCoordinate) => {
+		const gradient = 155 / 80;
+		const constant = 480 - 600 * gradient;
+		return (yCoordinate - constant) / gradient;
+	};
+
+	const calculateXcoordinateLower = (yCoordinate) => {
+		const gradient = 100 / 120;
+		const constant = 705 - 680 * gradient;
+		return (yCoordinate - constant) / gradient;
+	};
+
 	const drag = (event) => {
 		if (active) {
 			event.preventDefault();
-			currentMousePosition.x = event.clientX - initialMousePosition.x;
+			if (event.clientY - initialMousePosition.y < 545) {
+				currentMousePosition.x =
+          calculateXcoordinateUpper(event.clientY) - initialMousePosition.x;
+			} else if (event.clientY - initialMousePosition.y < 700) {
+				currentMousePosition.x =
+          calculateXcoordinateMiddle(event.clientY) - initialMousePosition.x;
+			} else {
+				currentMousePosition.x =
+          calculateXcoordinateLower(event.clientY) - initialMousePosition.x;
+			}
 			currentMousePosition.y = event.clientY - initialMousePosition.y;
+			// currentMousePosition.x = event.clientX - initialMousePosition.x;
 
 			offset.x = currentMousePosition.x;
 			offset.y = currentMousePosition.y;
@@ -77,6 +112,11 @@ const dragAndDropRover = () => {
 			setTranslate(currentMousePosition.x, currentMousePosition.y, roverSprite);
 		}
 	};
+
+	const mapImage = document.getElementById('rover-path-image');
+
+	mapImage.addEventListener('mousemove', drag, false);
+	mapImage.addEventListener('mouseup', dragEnd, false);
 
 	roverSprite.addEventListener('mousedown', dragStart, false);
 	roverSprite.addEventListener('mouseup', dragEnd, false);

--- a/app/marsRoverPath/index.js
+++ b/app/marsRoverPath/index.js
@@ -54,17 +54,96 @@ const dragAndDropRover = () => {
 		}
 	};
 
+	const DATA_POINTS = {
+		10: {
+			x: 1100,
+		},
+		40: {
+			x: 1100,
+		},
+		70: {
+			x: 1051,
+		},
+		100: {
+			x: 1014,
+		},
+		130: {
+			x: 987,
+		},
+		160: {
+			x: 970,
+		},
+		190: {
+			x: 933,
+		},
+		220: {
+			x: 870,
+		},
+		250: {
+			x: 870,
+		},
+		280: {
+			x: 870,
+		},
+		310: {
+			x: 790,
+		},
+		340: {
+			x: 780,
+		},
+		370: {
+			x: 775,
+		},
+		400: {
+			x: 743,
+		},
+		430: {
+			x: 700,
+		},
+		460: {
+			x: 690,
+		},
+		490: {
+			x: 638,
+		},
+		520: {
+			x: 630,
+		},
+		550: {
+			x: 611,
+		},
+		580: {
+			x: 618,
+		},
+		610: {
+			x: 626,
+		},
+		640: {
+			x: 639,
+		},
+		670: {
+			x: 646,
+		},
+		700: {
+			x: 660,
+		},
+		730: {
+			x: 718,
+		},
+		760: {
+			x: 738,
+		},
+		790: {
+			x: 763,
+		},
+	};
+	const roundToNearest30 = (number) => {
+		return Math.round(number / 30) * 30;
+	};
+
 	const dragEnd = () => {
 		initialMousePosition.x = currentMousePosition.x;
 		initialMousePosition.y = currentMousePosition.y;
-
-		console.log(
-			'DRAG END',
-			'x',
-			initialMousePosition.x,
-			'y',
-			initialMousePosition.y
-		);
 		active = false;
 	};
 
@@ -72,39 +151,13 @@ const dragAndDropRover = () => {
 		element.style.transform = 'translate(' + xPos + 'px, ' + yPos + 'px)';
 	};
 
-	const calculateXcoordinateUpper = (yCoordinate) => {
-		const gradient = -545 / 500;
-		const constant = 700 - 600 * gradient;
-		return (yCoordinate - constant) / gradient;
-	};
-
-	const calculateXcoordinateMiddle = (yCoordinate) => {
-		const gradient = 155 / 80;
-		const constant = 480 - 600 * gradient;
-		return (yCoordinate - constant) / gradient;
-	};
-
-	const calculateXcoordinateLower = (yCoordinate) => {
-		const gradient = 100 / 120;
-		const constant = 705 - 680 * gradient;
-		return (yCoordinate - constant) / gradient;
-	};
-
 	const drag = (event) => {
 		if (active) {
 			event.preventDefault();
-			if (event.clientY - initialMousePosition.y < 545) {
-				currentMousePosition.x =
-          calculateXcoordinateUpper(event.clientY) - initialMousePosition.x;
-			} else if (event.clientY - initialMousePosition.y < 700) {
-				currentMousePosition.x =
-          calculateXcoordinateMiddle(event.clientY) - initialMousePosition.x;
-			} else {
-				currentMousePosition.x =
-          calculateXcoordinateLower(event.clientY) - initialMousePosition.x;
-			}
-			currentMousePosition.y = event.clientY - initialMousePosition.y;
-			// currentMousePosition.x = event.clientX - initialMousePosition.x;
+
+			currentMousePosition.y = roundToNearest30(event.clientY) + 10;
+			currentMousePosition.x =
+        DATA_POINTS['' + (roundToNearest30(event.clientY) + 10)].x - 1100;
 
 			offset.x = currentMousePosition.x;
 			offset.y = currentMousePosition.y;


### PR DESCRIPTION
**Description**
If a user drops the rover close to the path (a range of something sensible), make the rover snap to somewhere sensible on the path.

The sprite for Curiosity should start on the start of its path across Mars.

**Changes**
* adds defined data points to the rover path to which the sprite will snap
* adds an event listener to the rover map image 