### PR TITLE
marsRover75: creates JTI and EXP claim on JWT and inserts values into jwtIds table

### DIFF
--- a/database/models.js
+++ b/database/models.js
@@ -21,6 +21,20 @@ const Users = database.define('users', {
 	},
 });
 
+const JwtIds = database.define('jwtIds', {
+	jti: {
+		type: Sequelize.STRING,
+		primaryKey: true,
+	},
+	exp: {
+		type: Sequelize.BIGINT,
+	},
+	userId: {
+		type: Sequelize.STRING,
+	},
+});
+
 module.exports = {
 	Users,
+	JwtIds,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3283,9 +3283,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "pg-hstore": "^2.3.3",
     "sequelize": "^6.3.5",
     "shortid": "^2.2.16",
+    "uuid": "^8.3.2",
     "winston": "^3.3.3"
   },
   "husky": {

--- a/server/middleware/checkForUser.js
+++ b/server/middleware/checkForUser.js
@@ -12,6 +12,7 @@ const checkForUser = (request, response, next) => {
 	})
 		.then((data) => {
 			if (data[0]) {
+				request.body.userId = data[0].dataValues.userId;
 				next();
 			} else {
 				response.redirect('/login');

--- a/server/middleware/insertJtiIntoDB.js
+++ b/server/middleware/insertJtiIntoDB.js
@@ -8,12 +8,12 @@ const insertJtiIntoDB = (request, response, next) => {
 	const TEN_MINS_IN_SECONDS = 10 * 60;
 	const expiryTime = Math.floor(Date.now() / 1000) + TEN_MINS_IN_SECONDS;
 
-	request.body.exp = expiryTime;
-	request.body.jti = jti;
-
 	JwtIds.create({ jti, exp: expiryTime, userId }).catch((error) => {
 		logger.warn(`${error.title}: ${error.message}`);
 	});
+
+	request.body.exp = expiryTime;
+	request.body.jti = jti;
 
 	next();
 };

--- a/server/middleware/insertJtiIntoDB.js
+++ b/server/middleware/insertJtiIntoDB.js
@@ -1,0 +1,23 @@
+const { JwtIds } = require('../../database/models');
+const { v4: uuidv4 } = require('uuid');
+const logger = require('../../config/logger');
+
+const insertJtiIntoDB = (request, response, next) => {
+	const { userId } = request.body;
+	const jti = uuidv4();
+	const TEN_MINS_IN_SECONDS = 10 * 60;
+	const expiryTime = Math.floor(Date.now() / 1000) + TEN_MINS_IN_SECONDS;
+
+	request.body.exp = expiryTime;
+	request.body.jti = jti;
+
+	JwtIds.create({ jti, exp: expiryTime, userId }).catch((error) => {
+		logger.warn(`${error.title}: ${error.message}`);
+	});
+
+	next();
+};
+
+module.exports = {
+	insertJtiIntoDB,
+};

--- a/server/middleware/insertJtiIntoDB.js
+++ b/server/middleware/insertJtiIntoDB.js
@@ -6,13 +6,14 @@ const insertJtiIntoDB = (request, response, next) => {
 	const { userId } = request.body;
 	const jti = uuidv4();
 	const TEN_MINS_IN_SECONDS = 10 * 60;
-	const expiryTime = Math.floor(Date.now() / 1000) + TEN_MINS_IN_SECONDS;
+	const expiryTimeinSeconds =
+    Math.floor(Date.now() / 1000) + TEN_MINS_IN_SECONDS;
 
-	JwtIds.create({ jti, exp: expiryTime, userId }).catch((error) => {
+	JwtIds.create({ jti, exp: expiryTimeinSeconds, userId }).catch((error) => {
 		logger.warn(`${error.title}: ${error.message}`);
 	});
 
-	request.body.exp = expiryTime;
+	request.body.exp = expiryTimeinSeconds;
 	request.body.jti = jti;
 
 	next();

--- a/server/middleware/setJwt.js
+++ b/server/middleware/setJwt.js
@@ -2,8 +2,8 @@ const jwt = require('jsonwebtoken');
 const { PRIVATE_KEY } = require('../../config/apiCredentials');
 
 const setJwtOnAccessToken = (request, response) => {
-	const { username, password, userId, exp, jti } = request.body;
-	const token = jwt.sign({ username, password, userId, exp, jti }, PRIVATE_KEY);
+	const { username, password, exp, jti } = request.body;
+	const token = jwt.sign({ username, password, exp, jti }, PRIVATE_KEY);
 	response.cookie('access_token', token, { httpOnly: true });
 	response.redirect('/');
 };

--- a/server/middleware/setJwt.js
+++ b/server/middleware/setJwt.js
@@ -2,9 +2,8 @@ const jwt = require('jsonwebtoken');
 const { PRIVATE_KEY } = require('../../config/apiCredentials');
 
 const setJwtOnAccessToken = (request, response) => {
-	const { username, password } = request.body;
-	const token = jwt.sign({ username, password }, PRIVATE_KEY);
-
+	const { username, password, userId, exp, jti } = request.body;
+	const token = jwt.sign({ username, password, userId, exp, jti }, PRIVATE_KEY);
 	response.cookie('access_token', token, { httpOnly: true });
 	response.redirect('/');
 };

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -8,6 +8,7 @@ const {
 	getImageAndExplanationForHomepage,
 } = require('../middleware/getPhotoAndTextForHomepage.js');
 const { registerUser } = require('../middleware/registerUser');
+const { insertJtiIntoDB } = require('../middleware/insertJtiIntoDB');
 
 const router = express.Router();
 
@@ -17,9 +18,14 @@ router.use('/login', express.static('app/login'));
 router.use('/register', express.static('app/register'));
 
 router.get('/apod', getImageAndExplanationForHomepage);
-router.post('/authenticate', checkForUser, setJwtOnAccessToken);
-router.post('/registration', registerUser, setJwtOnAccessToken);
 router.get('/getUsername', getUsername);
+router.post(
+	'/authenticate',
+	checkForUser,
+	insertJtiIntoDB,
+	setJwtOnAccessToken
+);
+router.post('/registration', registerUser, setJwtOnAccessToken);
 
 router.use('/user', [
 	passport.authenticate('jwt', { session: false, failureRedirect: '/login' }),


### PR DESCRIPTION
**Description**
In order to create a secure logout service, we need to firstly change the way we login. Rather than logging and setting a JWT with a username and password, we want to set a JWT with a JWT id and an exp claim. 
This PR creates the JTI and EXP claims, inserts them into the database and then adds them to the JWT.

**Changes**
* adds a model for the `jwtIds` table
* adds `uuid` for creating the JWT Id
* adds the `userId` to the `request.body` so that later it can be inserted into the `jwtIds` table
* inserts the `jti`, `exp` and `userId` values into the `jwtIds` table
* signs the JWT with the `exp` and `jti` values (`username` and `password` have been left in for now but will be removed in the next PR as removal requires some refactoring of other areas of the code).