### PR TITLE
marsRover75b: 

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -30,7 +30,7 @@ const configurePassport = () => {
 				},
 			})
 				.then((data) => {
-					if (data[0].exists) {
+					if (data.length > 0) {
 						return done(null, jwt_payload);
 					} else {
 						return done(null, false);

--- a/server/middleware/authenticateUser.js
+++ b/server/middleware/authenticateUser.js
@@ -1,0 +1,15 @@
+const passport = require('passport');
+
+const authenticateUser = (request, response, next) => {
+	passport.authenticate('jwt', (error, user) => {
+		if (error) {
+			return next(error);
+		}
+		if (!user) {
+			return response.json({ username: '' });
+		}
+		next();
+	})(request, response, next);
+};
+
+module.exports = { authenticateUser };

--- a/server/middleware/getUsername.js
+++ b/server/middleware/getUsername.js
@@ -1,16 +1,24 @@
 const jwtDecode = require('jwt-decode');
+const logger = require('../../config/logger');
+const { JwtIds, Users } = require('../../database/models');
 
 const getUsername = (request, response) => {
 	const accessToken = request.cookies.access_token;
 	try {
 		if (accessToken) {
-			const { username } = jwtDecode(accessToken);
-			response.json({ username });
+			const { jti } = jwtDecode(accessToken);
+			JwtIds.findAll({ where: { jti: jti } }).then((data) => {
+				Users.findAll({ where: { userId: data[0].dataValues.userId } }).then(
+					(data) => {
+						response.json({ username: data[0].dataValues.username });
+					}
+				);
+			});
 		} else {
 			response.json({});
 		}
 	} catch (error) {
-		console.log(error);
+		logger.warn(`${error.title}: ${error.message}`);
 	}
 };
 

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -17,10 +17,6 @@ router.use(express.static('./app/homepage'));
 router.use(express.static('./app/services'));
 router.use('/login', express.static('app/login'));
 router.use('/register', express.static('app/register'));
-router.use('/user', [
-	passport.authenticate('jwt', { session: false, failureRedirect: '/login' }),
-	user,
-]);
 
 router.get('/apod', getImageAndExplanationForHomepage);
 router.get('/getUsername', authenticateUser, getUsername);
@@ -31,6 +27,12 @@ router.post(
 	insertJtiIntoDB,
 	setJwtOnAccessToken
 );
+
 router.post('/registration', registerUser, setJwtOnAccessToken);
+
+router.use('/user', [
+	passport.authenticate('jwt', { session: false, failureRedirect: '/login' }),
+	user,
+]);
 
 module.exports = router;

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const passport = require('passport');
 const user = require('./routers/user');
-const { getUsername } = require('../middleware/getUsername');
 const { checkForUser } = require('../middleware/checkForUser');
 const { setJwtOnAccessToken } = require('../middleware/setJwt');
 const {
@@ -9,6 +8,8 @@ const {
 } = require('../middleware/getPhotoAndTextForHomepage.js');
 const { registerUser } = require('../middleware/registerUser');
 const { insertJtiIntoDB } = require('../middleware/insertJtiIntoDB');
+const { getUsername } = require('../middleware/getUsername');
+const { authenticateUser } = require('../middleware/authenticateUser');
 
 const router = express.Router();
 
@@ -16,9 +17,14 @@ router.use(express.static('./app/homepage'));
 router.use(express.static('./app/services'));
 router.use('/login', express.static('app/login'));
 router.use('/register', express.static('app/register'));
+router.use('/user', [
+	passport.authenticate('jwt', { session: false, failureRedirect: '/login' }),
+	user,
+]);
 
 router.get('/apod', getImageAndExplanationForHomepage);
-router.get('/getUsername', getUsername);
+router.get('/getUsername', authenticateUser, getUsername);
+
 router.post(
 	'/authenticate',
 	checkForUser,
@@ -26,10 +32,5 @@ router.post(
 	setJwtOnAccessToken
 );
 router.post('/registration', registerUser, setJwtOnAccessToken);
-
-router.use('/user', [
-	passport.authenticate('jwt', { session: false, failureRedirect: '/login' }),
-	user,
-]);
 
 module.exports = router;


### PR DESCRIPTION
**Description**
In order to create a secure logout service, we need to firstly change the way we login.
Rather than logging and setting a JWT with a username and password, we want to set a JWT with a JWT id and an eat claim. 
This PR removes the username and password from the JWT and refactors the implementation of the `getUsername` endpoint.

**Changes**
* removes the `password` and `username` from the JWT
* refactors getUsername to retrieve username from database rather than access token
* adds `authenticateUser` middleware which sets an empty string for the username if their is no user